### PR TITLE
Filepond Value wird nun aus dem Email Valuepool gezogen

### DIFF
--- a/lib/yform/action/filepond2email.php
+++ b/lib/yform/action/filepond2email.php
@@ -6,7 +6,7 @@ class rex_yform_action_filepond2email extends rex_yform_action_abstract {
     {
         $label_from = $this->getElement(2);
 
-        foreach ($this->params['value_pool']['sql'] as $key => $value) {
+        foreach ($this->params['value_pool']['email'] as $key => $value) {
             if ($label_from == $key) {
                 foreach (explode(',',$value) as $filename) {
                     $this->params['value_pool']['email_attachments'][] = [$filename, rex_path::media().$filename];


### PR DESCRIPTION
Wenn das Filepond Feld als no_db gekennzeichnet war, war dort kein Wert vorhanden.