### PR TITLE
♻️ Remove redundant GD resource validation (Copilot feedback)

### DIFF
--- a/lib/api/api_filepond.php
+++ b/lib/api/api_filepond.php
@@ -866,12 +866,6 @@ class rex_api_filepond_uploader extends rex_api_function
             return;
         }
 
-        // Check if we have a valid GD resource
-        if (!is_resource($image) && !($image instanceof \GdImage)) {
-            $this->log('error', 'Invalid image resource for EXIF orientation fix');
-            return;
-        }
-
         // Rotate/flip based on orientation value
         switch ($orientation) {
             case 2: // Horizontal flip


### PR DESCRIPTION
Code Cleanup:
- Removed redundant is_resource() and instanceof \GdImage check
- The previous lib/api/api_filepond.phpimage check already handles all failure cases
- imagecreatefromjpeg() returns false on failure, caught by existing validation
- Simplified error handling while maintaining robustness

Benefits:
- Cleaner, more maintainable code
- Addresses Copilot AI code review feedback
- No functional changes, same error protection
- Improved code readability